### PR TITLE
added span+relation (R) version of evaluation

### DIFF
--- a/rst.py
+++ b/rst.py
@@ -38,18 +38,23 @@ def load_edus(name):
     with open(name) as f:
         return [line.strip() for line in f]
 
-# primarily for evaluation -- make a "view" of the tree nodes to compare
+# primarily for evaluation -- make a "view" of the tree nodes to compare (S)
 def iter_spans_only(treenodes):
     for t in treenodes:
         yield t.span
 
-# for evaluation, must get the span and the nuclearity right
+# for evaluation, must get the span and the nuclearity right (N)
 def iter_nuclearity_spans(treenodes):
     for t in treenodes:
         yield f'{t.span}::{t.direction}'
 
-# for evaluation -- must get everything right
+# for evaluation -- must get span and relation label right (R)
 def iter_labeled_spans(treenodes):
+    for t in treenodes:
+        yield f'{t.span}::{t.label}'
+
+# for evaluation -- must get everything right (F)
+def iter_labeled_spans_with_nuclearity(treenodes):
     for t in treenodes:
         yield f'{t.span}::{t.direction}::{t.label}'
 

--- a/train.py
+++ b/train.py
@@ -6,7 +6,7 @@ from sklearn.metrics import balanced_accuracy_score, classification_report
 from sklearn.model_selection import train_test_split
 from transformers import AdamW, get_linear_schedule_with_warmup
 from model import DiscoBertModel
-from rst import load_annotations, iter_spans_only, iter_nuclearity_spans, iter_labeled_spans
+from rst import load_annotations, iter_spans_only, iter_nuclearity_spans, iter_labeled_spans, iter_labeled_spans_with_nuclearity
 from utils import prf1
 import config
 import engine
@@ -61,8 +61,11 @@ def main():
         # print(f'N (span + dir)  P:{p:.2%}\tR:{r:.2%}\tF1:{f1:.2%}')
         print(f'N (span + dir)  F1:{f1:.2%}')
         p, r, f1 = eval_trees(pred_trees, gold_trees, iter_labeled_spans)
+        # print(f'R (span + label)        P:{p:.2%}\tR:{r:.2%}\tF1:{f1:.2%}')
+        print(f'R (span + label)        F1:{f1:.2%}')
+        p, r, f1 = eval_trees(pred_trees, gold_trees, iter_labeled_spans_with_nuclearity)
         # print(f'R (full)        P:{p:.2%}\tR:{r:.2%}\tF1:{f1:.2%}')
-        print(f'R (full)        F1:{f1:.2%}')
+        print(f'F (full)        F1:{f1:.2%}')
         if f1 > best_f1:
             model.save(config.MODEL_PATH)
             best_f1 = f1


### PR DESCRIPTION
I added span-relation evaluation. Here are the results (same seed/num of epochs; on the left, it's both R and Full scores):

![Screenshot from 2020-06-19 11-23-38](https://user-images.githubusercontent.com/31713912/85169167-408e8100-b220-11ea-8e00-6d164079cdd6.png)

@marcovzla, to me it sounds like you, Mihai, and Tom used full based on this sentence from the paper: 

"We report end-to-end results on the 18 relations with nuclearity information used by (Hernault et al.,  2010;  Feng and Hirst,2012)," (p. 3, Surdeanu et al, 2015),

... and also based on the fact that in the eval code includes the word `scoreTypeFull`. I also thought that it was Full based on the code here: 

https://github.com/clulab/processors/blob/4890c0c64c9d107666330a1d8e3ca7371edc8729/main/src/main/scala/org/clulab/discourse/rstparser/DiscourseScorer.scala#L72

@BeckySharp and @marcovzla, does that sound right? Or does that line from the paper mean nuclearity was used as one of the features for label prediction and not that the system was evaluated on nuclearity?

I, for some reason, thought you were saying there was only R in Mihai, Marco, and Tom's paper. Also, in the paper that compares micro and marco scores from RST discourse parsers (https://www.aclweb.org/anthology/D17-1136.pdf) to me it looked like they were saying in Surdeanu, 2015, you (Marco) used R instead of F (the R score is underlined in Table 2 on p. 1321 as one of the scores they expect to match those reported in the original paper). 



