### PR TITLE
some dimension quirks

### DIFF
--- a/model.py
+++ b/model.py
@@ -76,7 +76,7 @@ class DiscoBertModel(nn.Module):
         if len(actions) == 1:
             # only one legal action available
             return self.action_to_id[actions[0]]
-        elif len(actions) == scores.shape[0]:
+        elif len(actions) == scores.shape[1]:
             # all actions are legal
             return torch.argmax(scores)
         else:

--- a/model.py
+++ b/model.py
@@ -83,7 +83,7 @@ class DiscoBertModel(nn.Module):
             # some actions are illegal, beware
             action_ids = [self.action_to_id[a] for a in actions]
             mask = torch.ones_like(scores) * -inf
-            mask[action_ids] = 0
+            mask[:, action_ids] = 0
             masked_scores = scores + mask
             return torch.argmax(masked_scores)
 


### PR DESCRIPTION
I changed a dimension in best_legal_action because I think the size of dim=0 is always 1 for the scores tensor `tensor([[-0.0055,  0.1544]])`

This did not influence the results from classifier with two actions:
if there was only one legal action, that is the action that got returned:
https://github.com/marcovzla/discobert/blob/2e6f1fe0d0cd508bfa97de480a2fe40e8c27f67d/model.py#L76

if there were two legal actions, both of them got masked correctly (for some reason---more on that below): 
https://github.com/marcovzla/discobert/blob/2e6f1fe0d0cd508bfa97de480a2fe40e8c27f67d/model.py#L86

This is only an issue if there are more than 2 actions.

Also, this masking

https://github.com/marcovzla/discobert/blob/2e6f1fe0d0cd508bfa97de480a2fe40e8c27f67d/model.py#L86

does not seem to work correctly if the number of items in the list to mask is not equal to the number of items to mask? Here are some outputs from when there are three actions:

masked correctly:
```
scores:  tensor([[ 0.3933, -0.3062,  0.1215]], device='cuda:0',
       grad_fn=<UnsqueezeBackward0>)
action ids: [0, 1, 2]
mask:  tensor([[0., 0., 0.]], device='cuda:0')
```

masked correctly:
```
scores:  tensor([[ 0.2237, -0.2750,  0.0463]], device='cuda:0',
       grad_fn=<UnsqueezeBackward0>)
action ids: [0, 1, 2]
mask:  tensor([[0., 0., 0.]], device='cuda:0')
```

masked wrong:
```
scores:  tensor([[ 0.2023, -0.2509,  0.3609]], device='cuda:0',
       grad_fn=<UnsqueezeBackward0>)
action ids: [1, 2]
mask:  tensor([[-inf, -inf, -inf]], device='cuda:0')
```

I tried to replicate this in the shell, but I can't. Trying to mask this way, I get the index out of bounds error, but the mask is still updated. There's also a good chance I am just missing something about how tensors work, but I can't track it down. Could have to do with the fact that action scores have been unsqueezed? I'm quite confused. 

In one of my other branches, where this is crucial, I opted for now for a for-loop. If the loop looks right to you, I could add it with this PR. Here's the loop:

```
for i in action_ids:
    mask[0][i] = 0
```

